### PR TITLE
Add credit card name field to form

### DIFF
--- a/CreditCardEntry/res/values-de/strings.xml
+++ b/CreditCardEntry/res/values-de/strings.xml
@@ -3,5 +3,7 @@
     <string name="CreditCardNumberHelp"/>
     <string name="ExpirationDateHelp">Ablaufdatum (MM/YY)</string>
     <string name="SecurityCodeHelp">Sicherheitscode (CVV)</string>
+    <string name="CVV">CVV</string>
     <string name="ZipHelp">Postleitzahl</string>
+    <string name="NameHelp">Name</string>
 </resources>

--- a/CreditCardEntry/res/values-es/strings.xml
+++ b/CreditCardEntry/res/values-es/strings.xml
@@ -3,6 +3,8 @@
     <string name="CreditCardNumberHelp"/>
     <string name="ExpirationDateHelp">Fecha de caducidad (MM/YY)</string>
     <string name="SecurityCodeHelp">Código de seguridad (CVV)</string>
+    <string name="CVV">CVV</string>
     <string name="ZipHelp">Código postal</string>
+    <string name="NameHelp">Nombre</string>
 
 </resources>

--- a/CreditCardEntry/res/values-fr/strings.xml
+++ b/CreditCardEntry/res/values-fr/strings.xml
@@ -3,5 +3,7 @@
     <string name="CreditCardNumberHelp"/>
     <string name="ExpirationDateHelp">Date d\'expiration (MM/YY)</string>
     <string name="SecurityCodeHelp">Code de sécurité (CVV)</string>
+    <string name="CVV">CVV</string>
     <string name="ZipHelp">Code postal</string>
+    <string name="NameHelp">Nom</string>
 </resources>

--- a/CreditCardEntry/res/values-it/strings.xml
+++ b/CreditCardEntry/res/values-it/strings.xml
@@ -3,5 +3,7 @@
     <string name="CreditCardNumberHelp"/>
     <string name="ExpirationDateHelp">Data di scadenza (MM/YY)</string>
     <string name="SecurityCodeHelp">Codice di sicurezza (CVV)</string>
+    <string name="CVV">CVV</string>
     <string name="ZipHelp">Codice postale</string>
+    <string name="NameHelp">Nome</string>
 </resources>

--- a/CreditCardEntry/res/values-pt/strings.xml
+++ b/CreditCardEntry/res/values-pt/strings.xml
@@ -3,5 +3,7 @@
     <string name="CreditCardNumberHelp"/>
     <string name="ExpirationDateHelp">Data de validade (MM/YY)</string>
     <string name="SecurityCodeHelp">Código de segurança (CVV)</string>
+    <string name="CVV">CVV</string>
     <string name="ZipHelp">Código postal</string>
+    <string name="NameHelp">Nome</string>
 </resources>

--- a/CreditCardEntry/res/values/attrs.xml
+++ b/CreditCardEntry/res/values/attrs.xml
@@ -5,6 +5,7 @@
         <attr name="include_security"   format="boolean"/>
         <attr name="include_zip"        format="boolean"/>
         <attr name="include_helper"     format="boolean"/>
+        <attr name="include_name"       format="boolean"/>
 
         <attr name="helper_text_color"  format="color"/>
         <attr name="text_color"         format="color"/>

--- a/CreditCardEntry/res/values/ids.xml
+++ b/CreditCardEntry/res/values/ids.xml
@@ -7,6 +7,7 @@
     <item name="cc_exp" type="id">3333</item>
     <item name="cc_ccv" type="id">4444</item>
     <item name="cc_zip" type="id">5555</item>
+    <item name="cc_name" type="id">6666</item>
     <item name="text_helper" type="id">2000</item>
     <item name="null_color" type="color">234234</item>
 </resources>

--- a/CreditCardEntry/res/values/strings.xml
+++ b/CreditCardEntry/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="CreditCardNumberHelp"/>
     <string name="ExpirationDateHelp">Expiration date (MM/YY)</string>
     <string name="SecurityCodeHelp">Security code (CVV)</string>
+    <string name="CVV">CVV</string>
     <string name="ZipHelp">Postal code</string>
     <string name="NameHelp">Name on card</string>
 

--- a/CreditCardEntry/res/values/strings.xml
+++ b/CreditCardEntry/res/values/strings.xml
@@ -4,5 +4,6 @@
     <string name="ExpirationDateHelp">Expiration date (MM/YY)</string>
     <string name="SecurityCodeHelp">Security code (CVV)</string>
     <string name="ZipHelp">Postal code</string>
+    <string name="NameHelp">Name on card</string>
 
 </resources>

--- a/CreditCardEntry/src/com/devmarvel/creditcardentry/fields/NameText.java
+++ b/CreditCardEntry/src/com/devmarvel/creditcardentry/fields/NameText.java
@@ -1,0 +1,62 @@
+package com.devmarvel.creditcardentry.fields;
+
+import android.content.Context;
+import android.text.InputType;
+import android.text.TextUtils;
+import android.util.AttributeSet;
+import android.view.Gravity;
+
+import com.devmarvel.creditcardentry.R;
+
+/**
+ * Created by Perry Street Software Inc. on Nov 28, 2016.
+ *
+ * @author Steve Tsourounis {steve@scruff.com}
+ */
+
+public class NameText extends CreditEntryFieldBase {
+
+	private String mHelperText;
+
+	public NameText(Context context) {
+		super(context);
+	}
+
+	public NameText(Context context, AttributeSet attrs) {
+		super(context, attrs);
+	}
+
+	public NameText(Context context, AttributeSet attrs, int defStyle) {
+		super(context, attrs, defStyle);
+	}
+
+	@Override
+	void init(AttributeSet attrs) {
+		super.init(attrs);
+		this.setHint(R.string.NameHelp);
+		this.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PERSON_NAME);
+		this.setGravity(Gravity.START);
+	}
+
+	@Override
+	public boolean isValid() {
+		return !TextUtils.isEmpty(getText());
+	}
+
+	@Override
+	public void setHelperText(String helperText) {
+		this.mHelperText = helperText;
+	}
+
+	@Override
+	public String getHelperText() {
+		return (mHelperText != null ? mHelperText : context.getString(R.string.NameHelp));
+	}
+
+	@Override
+	public void formatAndSetText(String updatedString) {
+		this.removeTextChangedListener(this);
+		this.setText(updatedString);
+		this.addTextChangedListener(this);
+	}
+}

--- a/CreditCardEntry/src/com/devmarvel/creditcardentry/fields/SecurityCodeText.java
+++ b/CreditCardEntry/src/com/devmarvel/creditcardentry/fields/SecurityCodeText.java
@@ -2,7 +2,6 @@ package com.devmarvel.creditcardentry.fields;
 
 import android.content.Context;
 import android.text.Editable;
-import android.text.InputFilter;
 import android.util.AttributeSet;
 
 import com.devmarvel.creditcardentry.R;
@@ -34,7 +33,7 @@ public class SecurityCodeText extends CreditEntryFieldBase {
 
 	void init() {
 		super.init();
-		setHint("CVV");
+		this.setHint(context.getString(R.string.CVV));
 	}
 
 	/* TextWatcher Implementation Methods */

--- a/CreditCardEntry/src/com/devmarvel/creditcardentry/internal/CreditCardEntry.java
+++ b/CreditCardEntry/src/com/devmarvel/creditcardentry/internal/CreditCardEntry.java
@@ -41,6 +41,7 @@ import com.devmarvel.creditcardentry.R;
 import com.devmarvel.creditcardentry.fields.CreditCardText;
 import com.devmarvel.creditcardentry.fields.CreditEntryFieldBase;
 import com.devmarvel.creditcardentry.fields.ExpDateText;
+import com.devmarvel.creditcardentry.fields.NameText;
 import com.devmarvel.creditcardentry.fields.SecurityCodeText;
 import com.devmarvel.creditcardentry.fields.ZipCodeText;
 import com.devmarvel.creditcardentry.library.CardType;
@@ -66,10 +67,11 @@ public class CreditCardEntry extends HorizontalScrollView implements
     private final ExpDateText expDateText;
     private final SecurityCodeText securityCodeText;
     private final ZipCodeText zipCodeText;
+    private NameText nameText;
 
     private Map<CreditEntryFieldBase, CreditEntryFieldBase> nextFocusField = new HashMap<>(4);
     private Map<CreditEntryFieldBase, CreditEntryFieldBase> prevFocusField = new HashMap<>(4);
-    private List<CreditEntryFieldBase> includedFields = new ArrayList<>(4);
+    private List<CreditEntryFieldBase> includedFields = new ArrayList<>();
 
     private final TextView textFourDigits;
 
@@ -417,6 +419,15 @@ public class CreditCardEntry extends HorizontalScrollView implements
         this.textHelper = textHelper;
     }
 
+    public NameText getNameEditText() {
+        return this.nameText;
+    }
+
+    public void setNameEditText(@NonNull NameText nameText) {
+        this.nameText = nameText;
+        this.includedFields.add(this.nameText);
+    }
+
     public boolean isCreditCardValid() {
         for (CreditEntryFieldBase includedField : includedFields) {
             if (!includedField.isValid()) return false;
@@ -482,7 +493,8 @@ public class CreditCardEntry extends HorizontalScrollView implements
     }
 
     public CreditCard getCreditCard() {
-        return new CreditCard(creditCardText.getText().toString(), expDateText.getText().toString(),
+        String name = nameText != null ? nameText.getText().toString() : null;
+        return new CreditCard(name, creditCardText.getText().toString(), expDateText.getText().toString(),
                 securityCodeText.getText().toString(), zipCodeText.getText().toString(),
                 creditCardText.getType());
     }

--- a/CreditCardEntry/src/com/devmarvel/creditcardentry/library/CreditCard.java
+++ b/CreditCardEntry/src/com/devmarvel/creditcardentry/library/CreditCard.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 
 public class CreditCard implements Serializable {
 	
+	private final String name;
 	private final String cardNumber;
 	private final String expDate;
 	private final String securityCode;
@@ -11,12 +12,18 @@ public class CreditCard implements Serializable {
 	private final CardType cardType;
 
 
-	public CreditCard(String cardNumber, String expDate, String securityCode, String zipCode, CardType cardType) {
+	public CreditCard(String name, String cardNumber, String expDate, String securityCode, String zipCode, CardType cardType) {
+		this.name = name;
 		this.cardNumber = cardNumber;
 		this.expDate = expDate;
 		this.securityCode = securityCode;
 		this.zipCode = zipCode;
 		this.cardType = cardType;
+	}
+
+	@SuppressWarnings("unused")
+	public String getName() {
+		return name;
 	}
 
 	@SuppressWarnings("unused")
@@ -69,7 +76,8 @@ public class CreditCard implements Serializable {
 	@Override
 	public String toString() {
 		final StringBuilder sb = new StringBuilder("CreditCard{");
-		sb.append("cardNumber='").append(cardNumber).append('\'');
+		sb.append("name='").append(name).append('\'');
+		sb.append(", cardNumber='").append(cardNumber).append('\'');
 		sb.append(", expDate='").append(expDate).append('\'');
 		sb.append(", securityCode='").append(securityCode).append('\'');
 		sb.append(", zipCode='").append(zipCode).append('\'');

--- a/CreditCardEntry/src/com/devmarvel/creditcardentry/library/CreditCardForm.java
+++ b/CreditCardEntry/src/com/devmarvel/creditcardentry/library/CreditCardForm.java
@@ -20,6 +20,7 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import com.devmarvel.creditcardentry.R;
+import com.devmarvel.creditcardentry.fields.NameText;
 import com.devmarvel.creditcardentry.internal.CreditCardEntry;
 
 public class CreditCardForm extends RelativeLayout {
@@ -29,6 +30,7 @@ public class CreditCardForm extends RelativeLayout {
 	private boolean includeSecurity = true;
 	private boolean includeZip = true;
 	private boolean includeHelper;
+	private boolean includeName;
 	private int textHelperColor;
 	private Drawable inputBackground;
 	private boolean useDefaultColors;
@@ -65,6 +67,7 @@ public class CreditCardForm extends RelativeLayout {
 					this.includeSecurity = typedArray.getBoolean(R.styleable.CreditCardForm_include_security, true);
 					this.includeZip = typedArray.getBoolean(R.styleable.CreditCardForm_include_zip, true);
 					this.includeHelper = typedArray.getBoolean(R.styleable.CreditCardForm_include_helper, true);
+					this.includeName = typedArray.getBoolean(R.styleable.CreditCardForm_include_name, false);
 					this.textHelperColor = typedArray.getColor(R.styleable.CreditCardForm_helper_text_color, getResources().getColor(R.color.text_helper_color));
 					this.inputBackground = typedArray.getDrawable(R.styleable.CreditCardForm_input_background);
 					this.useDefaultColors = typedArray.getBoolean(R.styleable.CreditCardForm_default_text_colors, false);
@@ -86,6 +89,20 @@ public class CreditCardForm extends RelativeLayout {
 	}
 
 	private void init(Context context, AttributeSet attrs, int style) {
+
+		// Name EditText
+		NameText nameEditText = new NameText(context, attrs);
+		nameEditText.setId(R.id.cc_name);
+		LayoutParams layoutParams = new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT);
+		layoutParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
+		layoutParams.addRule(RelativeLayout.ALIGN_PARENT_TOP);
+		layoutParams.setMargins(0, 0, 0, 20);
+		nameEditText.setLayoutParams(layoutParams);
+		nameEditText.setBackgroundDrawable(inputBackground);
+		nameEditText.setPadding(20, 15, 20, 20);
+		nameEditText.setVisibility(includeName ? View.VISIBLE : View.GONE);
+		this.addView(nameEditText);
+
 		// the wrapper layout
 		LinearLayout layout;
 		if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
@@ -94,15 +111,15 @@ public class CreditCardForm extends RelativeLayout {
 			layout = new LinearLayout(context);
 		}
 
-        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-            //ignore RTL layout direction
-            layout.setLayoutDirection(LAYOUT_DIRECTION_LTR);
-        }
+		if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+			//ignore RTL layout direction
+			layout.setLayoutDirection(LAYOUT_DIRECTION_LTR);
+		}
 
 		layout.setId(R.id.cc_form_layout);
 		LayoutParams params = new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT);
 		params.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
-		params.addRule(RelativeLayout.ALIGN_PARENT_TOP);
+		params.addRule(RelativeLayout.BELOW, nameEditText.getId());
 		params.addRule(LinearLayout.HORIZONTAL);
 		params.setMargins(0, 0, 0, 0);
 		layout.setLayoutParams(params);
@@ -120,13 +137,13 @@ public class CreditCardForm extends RelativeLayout {
 		cardImageFrame.setPadding(10, 0, 0, 0);
 
 		ImageView cardFrontImage = new ImageView(context);
-		LayoutParams layoutParams = new LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
+		layoutParams = new LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
 		cardFrontImage.setLayoutParams(layoutParams);
 		cardFrontImage.setImageResource(CardType.INVALID.frontResource);
 		cardImageFrame.addView(cardFrontImage);
 
 		ImageView cardBackImage = new ImageView(context);
-		layoutParams = new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
+		layoutParams = new LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
 		cardBackImage.setLayoutParams(layoutParams);
 		cardBackImage.setImageResource(CardType.INVALID.backResource);
 		cardBackImage.setVisibility(View.GONE);
@@ -137,7 +154,7 @@ public class CreditCardForm extends RelativeLayout {
 		LinearLayout.LayoutParams entryParams = new LinearLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
 		entryParams.gravity = Gravity.CENTER_VERTICAL;
 		entry = new CreditCardEntry(context, includeExp, includeSecurity, includeZip, attrs, style);
-        entry.setId(R.id.cc_entry);
+		entry.setId(R.id.cc_entry);
 
 		// this obnoxious 6 for bottom padding is to make the damn text centered on the image... if you know a better way... PLEASE HELP
 		entry.setPadding(0, 0, 0, 6);
@@ -155,7 +172,7 @@ public class CreditCardForm extends RelativeLayout {
 		// set up optional helper text view
 		if (includeHelper) {
 			TextView textHelp = new TextView(context);
-            textHelp.setId(R.id.text_helper);
+			textHelp.setId(R.id.text_helper);
 			textHelp.setText(getResources().getString(R.string.CreditCardNumberHelp));
 			if (useDefaultColors) {
 				textHelp.setTextColor(this.textHelperColor);
@@ -167,6 +184,10 @@ public class CreditCardForm extends RelativeLayout {
 			textHelp.setLayoutParams(layoutParams);
 			entry.setTextHelper(textHelp);
 			this.addView(textHelp);
+		}
+
+		if (includeName) {
+			entry.setNameEditText(nameEditText);
 		}
 
 		layout.addView(entry);
@@ -336,38 +357,38 @@ public class CreditCardForm extends RelativeLayout {
 		});
 	}
 
-    /** helper & hint setting **/
+	/** helper & hint setting **/
 
-    public void setCreditCardTextHelper(String text) {
-        entry.setCreditCardTextHelper(text);
-    }
+	public void setCreditCardTextHelper(String text) {
+		entry.setCreditCardTextHelper(text);
+	}
 
-    public void setCreditCardTextHint(String text) {
-        entry.setCreditCardTextHint(text);
-    }
+	public void setCreditCardTextHint(String text) {
+		entry.setCreditCardTextHint(text);
+	}
 
-    public void setExpDateTextHelper(String text) {
-        entry.setExpDateTextHelper(text);
-    }
+	public void setExpDateTextHelper(String text) {
+		entry.setExpDateTextHelper(text);
+	}
 
-    public void setExpDateTextHint(String text) {
-        entry.setExpDateTextHint(text);
-    }
+	public void setExpDateTextHint(String text) {
+		entry.setExpDateTextHint(text);
+	}
 
-    public void setSecurityCodeTextHelper(String text) {
-        entry.setSecurityCodeTextHelper(text);
-    }
+	public void setSecurityCodeTextHelper(String text) {
+		entry.setSecurityCodeTextHelper(text);
+	}
 
-    public void setSecurityCodeTextHint(String text) {
-        entry.setSecurityCodeTextHint(text);
-    }
+	public void setSecurityCodeTextHint(String text) {
+		entry.setSecurityCodeTextHint(text);
+	}
 
-    public void setZipCodeTextHelper(String text) {
-        entry.setZipCodeTextHelper(text);
-    }
+	public void setZipCodeTextHelper(String text) {
+		entry.setZipCodeTextHelper(text);
+	}
 
-    public void setZipCodeTextHint(String text) {
-        entry.setZipCodeTextHint(text);
-    }
+	public void setZipCodeTextHint(String text) {
+		entry.setZipCodeTextHint(text);
+	}
 }
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ XML
    the application's theme.
  * `app:include_helper` - boolean to show/hide the helper text under the widget (`true` by default (i.e. helper is shown))
  * `app:helper_text_color` - change the text color of the hints that appear below the widget by default.
+ * `app:include_name` - boolean to show/hide the name on card in the form (`false` by default (i.e. name is not shown))
  * `app:include_zip` - boolean to show/hide the zip code in the form (`true` by default (i.e. zip is shown))
  * `app:include_exp` - boolean to show/hide the exp in the form (`true` by default (i.e. exp is shown))
  * `app:include_security` - boolean to show/hide the security code in the form (`true` by default (i.e. security is shown))
@@ -80,22 +81,22 @@ In code:
 
 ```
     public class MainActivity extends Activity {
-  
+
       private LinearLayout linearLayout;
       private CreditCardForm form;
-  
+
       protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-  
+
         setContentView(R.layout.activity_main);
     	linearLayout = (LinearLayout) findViewById(R.id.layer);
-		
+
         form = new CreditCardForm(this);
     	linearLayout.addView(form);
-    	
+
     	buttonAuthorize = (Button) findViewById(R.id.buttonAuthorize);
     	buttonAuthorize.setOnClickListener(new OnClickListener() {
-    		
+
     		@Override
     		public void onClick(View arg0) {
     			if(form.isCreditCardValid())
@@ -119,7 +120,7 @@ In code:
 # Version History
 
 ###3/30/2016
- - made the CreditCardForm work in RTL layout 
+ - made the CreditCardForm work in RTL layout
  - added getHelperText/setHelperText to CreditEntryFieldBase
  - added setting hint & helper texts to fields
 


### PR DESCRIPTION
Add an attribute (`app:include_name`) to the `com.devmarvel.creditcardentry.library.CreditCardForm` that will include an extra field to allow the user to enter the name on the card.

The default value of `app:include_name` is `false`.

The `name` value can be accessed via `CreditCard#getName()`.